### PR TITLE
Fix Dynamic assembly definition for dotnet core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Output/
 .cake/*
 !.cake/packages.config
 packages/
+.vs/

--- a/GroBuf/GroBuf/GroBufReader.cs
+++ b/GroBuf/GroBuf/GroBufReader.cs
@@ -20,7 +20,7 @@ namespace GroBuf
             this.options = options;
             this.factory = factory;
             this.baseFactory = baseFactory;
-            var assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(Guid.NewGuid().ToString()), AssemblyBuilderAccess.Run);
+            var assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(Guid.NewGuid().ToString()), AssemblyBuilderAccess.Run);
             module = assembly.DefineDynamicModule(Guid.NewGuid().ToString());
             readerCollection = new ReaderCollection(customSerializerCollection, factory, baseFactory, module);
         }

--- a/GroBuf/GroBuf/GroBufWriter.cs
+++ b/GroBuf/GroBuf/GroBufWriter.cs
@@ -20,7 +20,7 @@ namespace GroBuf
             this.options = options;
             sizeCounterCollection = new SizeCounterCollection(customSerializerCollection, factory, baseFactory);
             writerCollection = new WriterCollection(customSerializerCollection, factory, baseFactory);
-            assembly = AppDomain.CurrentDomain.DefineDynamicAssembly(new AssemblyName(Guid.NewGuid().ToString()), AssemblyBuilderAccess.Run);
+            assembly = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName(Guid.NewGuid().ToString()), AssemblyBuilderAccess.Run);
             module = assembly.DefineDynamicModule(Guid.NewGuid().ToString());
             trackReferences = options.HasFlag(GroBufOptions.PackReferences);
         }


### PR DESCRIPTION
AppDomain.CurrentDomain.DefineDynamicAssembly does not work in dotnet core, so use AssemblyBuilder.DefineDynamicAssembly instead.