### PR TITLE
support .net 7.0

### DIFF
--- a/GroBuf.Tests/GroBuf.Tests.csproj
+++ b/GroBuf.Tests/GroBuf.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net48;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GroBuf/PlatformHelpers.cs
+++ b/GroBuf/PlatformHelpers.cs
@@ -10,11 +10,13 @@ namespace GroBuf
             IsMono = HasSystemType("Mono.Runtime");
             IsDotNetCore30OrGreater = HasSystemType("System.Range");
             IsDotNet50OrGreater = HasSystemType("System.Half");
+            IsDotNet70OrGreater = HasSystemType("System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute");
         }
 
         public static bool IsMono { get; }
         public static bool IsDotNetCore30OrGreater { get; }
         public static bool IsDotNet50OrGreater { get; }
+        public static bool IsDotNet70OrGreater { get; }
 
         public static string DelegateTargetFieldName => IsMono ? "m_target" : "_target";
         public static string[] LazyValueFactoryFieldNames => new[] {"m_valueFactory", "_factory"};
@@ -22,6 +24,7 @@ namespace GroBuf
         public static string[] DateTimeOffsetOffsetMinutesFieldNames => new[] {"m_offsetMinutes", "_offsetMinutes"};
         public static string[] HashtableCountFieldNames => new[] {"count", "_count"};
         public static string[] HashtableBucketsFieldNames => new[] {"buckets", "_buckets"};
+        public static string HashtableBucketTypeName => IsDotNet70OrGreater ? "Bucket" : "bucket";
         public static string[] HashSetCountFieldNames => IsDotNet50OrGreater ? new[] {"_count"} : new[] {"m_lastIndex", "_lastIndex"};
         public static string[] HashSetSlotsFieldNames => IsDotNet50OrGreater ? new[] {"_entries"} : new[] {"m_slots", "_slots"};
         public static string[] DictionaryCountFieldNames => new[] {"count", "_count"};

--- a/GroBuf/SizeCounters/HashtableSizeCounterBuilder.cs
+++ b/GroBuf/SizeCounters/HashtableSizeCounterBuilder.cs
@@ -45,7 +45,7 @@ namespace GroBuf.SizeCounters
             il.Brfalse(doneLabel); // if(count == 0) goto done; stack: [size]
 
             context.LoadObj(); // stack: [size, obj]
-            var bucketType = Type.GetNestedType("bucket", BindingFlags.NonPublic);
+            var bucketType = Type.GetNestedType(PlatformHelpers.HashtableBucketTypeName, BindingFlags.NonPublic);
             var buckets = il.DeclareLocal(bucketType.MakeArrayType());
             var bucketsField = Type.GetPrivateInstanceField(PlatformHelpers.HashtableBucketsFieldNames);
             il.Ldfld(bucketsField); // stack: [size, obj.buckets]

--- a/GroBuf/Writers/HashtableWriterBuilder.cs
+++ b/GroBuf/Writers/HashtableWriterBuilder.cs
@@ -58,7 +58,7 @@ namespace GroBuf.Writers
             il.Brfalse(writeDataLengthLabel); // if(count == 0) goto writeDataLength; stack: []
 
             context.LoadObj(); // stack: [obj]
-            var bucketType = Type.GetNestedType("bucket", BindingFlags.NonPublic);
+            var bucketType = Type.GetNestedType(PlatformHelpers.HashtableBucketTypeName, BindingFlags.NonPublic);
             var buckets = il.DeclareLocal(bucketType.MakeArrayType());
             var bucketsField = Type.GetPrivateInstanceField(PlatformHelpers.HashtableBucketsFieldNames);
             il.Ldfld(bucketsField); // stack: [obj.buckets]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "7.0.0",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
In .Net 7 nested type `bucket` of `Hashtable` was renamed to `Bucket` ( https://github.com/dotnet/runtime/pull/62507 )

Fixed by checking runtime version. 

Also run tests on .NET 7.